### PR TITLE
bug fix

### DIFF
--- a/R/join_.R
+++ b/R/join_.R
@@ -386,7 +386,7 @@ join_location_properties <- function(database,
 
     compacted_locations_column <-
       locations %>% 
-      tidyr::nest(data = -dplyr::all_of(c("dataset_id", "location_id"))) %>%
+      tidyr::nest(data = -dplyr::all_of(c("dataset_id", "location_id", "location_name"))) %>%
       dplyr::mutate(location_properties = purrr::map_chr(data, jsonlite::toJSON)) %>%
       dplyr::select(-dplyr::any_of("data")) %>%
       dplyr::ungroup()

--- a/R/separate_trait_values.R
+++ b/R/separate_trait_values.R
@@ -53,7 +53,7 @@ separate_trait_values <- function(trait_data, definitions) {
     dplyr::bind_rows(out_1, out_2) %>% 
       dplyr::select(-n_vals) %>% 
       dplyr::mutate(replicates = clean_NA(replicates),
-                    value_type = factor(clean_NA(value_type), levels = names(definitions$definitions$value_type$values))
+                    value_type = clean_NA(value_type)
       ) %>% 
       dplyr::arrange(observation_id, trait_name, value_type)
   }

--- a/tests/testthat/test-flatten_database.R
+++ b/tests/testthat/test-flatten_database.R
@@ -29,7 +29,7 @@ test_that("`flatten_database` defaults to `single_column_pretty` for contributor
 })
 
 test_that("`flatten_database` is working with format = single_column_json", {
-  expect_no_error(combined_table_json <- flatten_database(database2, format = "single_column_json"))
+  expect_no_error(combined_table_json <- flatten_database(database_2, format = "single_column_json"))
   expect_contains(names(combined_table_json), "location_name")
   expect_length(combined_table_json, 66)
   expect_true(stringr::str_detect(combined_table_json$location_properties[1], "^\\[\\{"))
@@ -37,7 +37,7 @@ test_that("`flatten_database` is working with format = single_column_json", {
 })
 
 test_that("`flatten_database` is working with format = many_columns", {
-  expect_no_error(combined_table_many <- flatten_database(database2, format = "many_columns"))
+  expect_no_error(combined_table_many <- flatten_database(database_2, format = "many_columns"))
   expect_contains(names(combined_table_many), "location_name")
   expect_contains(names(combined_table_many), "temporal_context: sampling season")
 })

--- a/tests/testthat/test-flatten_database.R
+++ b/tests/testthat/test-flatten_database.R
@@ -28,6 +28,20 @@ test_that("`flatten_database` defaults to `single_column_pretty` for contributor
   expect_equal(combined_table_3a$data_contributors, combined_table_3b$data_contributors)
 })
 
+test_that("`flatten_database` is working with format = single_column_json", {
+  expect_no_error(combined_table_json <- flatten_database(database2, format = "single_column_json"))
+  expect_contains(names(combined_table_json), "location_name")
+  expect_length(combined_table_json, 66)
+  expect_true(stringr::str_detect(combined_table_json$location_properties[1], "^\\[\\{"))
+  expect_true(stringr::str_detect(combined_table_json$data_contributors[1], "^\\[\\{"))
+})
+
+test_that("`flatten_database` is working with format = many_columns", {
+  expect_no_error(combined_table_many <- flatten_database(database2, format = "many_columns"))
+  expect_contains(names(combined_table_many), "location_name")
+  expect_contains(names(combined_table_many), "temporal_context: sampling season")
+})
+
 # test that join_location_coordinates works as intended
 
 database_no_coord <- austraits_5.0.0_lite %>% extract_dataset("Kooyman_2011")


### PR DESCRIPTION
- `join_location_properties(format = "single_column_json")` was not retaining `location_name` as its own column.
 
- Both fixed this and added tests

- Also, `value_type` was being lost during `separate_trait_values` - and probably has been for a long time.