### PR TITLE
Super minor patch: Updated actions/cache version #142 

### DIFF
--- a/.github/workflows/pkgdown_deploy.yml
+++ b/.github/workflows/pkgdown_deploy.yml
@@ -27,7 +27,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore R package cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -30,7 +30,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore R package cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
- Closes #142 
- Updated actions/cache version to v4 as <=v2 is no longer supported. Used in test coverage and pkgdown
- Bumped minor patch in version number
