### PR TITLE
Bug fix

### DIFF
--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -213,9 +213,12 @@ extract_data <- function(database, table = NA, col, col_value) {
               dplyr::distinct()
          
          }
-        
+
         if (ncol(database[["excluded_data"]]) == 0) {
             database[["excluded_data"]] <- database[["traits"]][0,]
+            database[["excluded_data"]] <- database[["excluded_data"]] %>% 
+              dplyr::mutate(error = character()) %>%
+              dplyr::select(error, everything())
         }
         
       }

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -214,7 +214,7 @@ extract_data <- function(database, table = NA, col, col_value) {
          
          }
         
-        if (database[["excluded_data"]] == 0) {
+        if (ncol(database[["excluded_data"]]) == 0) {
             database[["excluded_data"]] <- database[["traits"]][0,]
         }
         

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -214,6 +214,10 @@ extract_data <- function(database, table = NA, col, col_value) {
          
          }
         
+        if (database[["excluded_data"]] == 0) {
+            database[["excluded_data"]] <- database[["traits"]][0,]
+        }
+        
       }
     
     # Rejoin contexts

--- a/tests/testthat/test-extract_.R
+++ b/tests/testthat/test-extract_.R
@@ -117,6 +117,7 @@ test_that("that you can link two calls of `extract_data` together", {
   expect_no_error(extract_data(database = subset_by_dataset_id3, table = "contexts", col = "context_property", col_value = "age"))
   expect_no_error(subset_by_dataset_id_and_context <- extract_data(database = subset_by_dataset_id3, table = "contexts", col = "context_property", col_value = "age"))
   expect_gt(nrow(subset_by_dataset_id3$contexts), nrow(subset_by_dataset_id_and_context$contexts))
+  expect_equal(c("error", names(subset_by_dataset_id3$traits)), names(subset_by_dataset_id3$excluded_data))
   })
   
 test_that("extracts using generalised extract function behaves as expected - extracting by `life_stage", {


### PR DESCRIPTION
If there was no data in the excluded_data table, the extract_ functions were returning an empty tibble, not a tibble of empty named, columns. In addition to being the wrong output, this was leading to warnings when running multiple extract_ functions.

A change at the end of the main extract_data function fixes this
