### PR TITLE
fix bug in `load_austraits`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: austraits
 Title: Helpful functions to access the AusTraits database and wrangle data from other traits.build databases
-Version: 3.1.0.900
+Version: 3.1.1
 Authors@R:
     c(person(given = "Daniel",
              family = "Falster",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: austraits
 Title: Helpful functions to access the AusTraits database and wrangle data from other traits.build databases
-Version: 3.1.0
+Version: 3.1.0.900
 Authors@R:
     c(person(given = "Daniel",
              family = "Falster",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# austraits 3.1.1
+- Fix bug in function `load_austraits` that was preventing it from loading austraits.build v.7.0.0, as both relational and flattened database versions are now on Zenodo. For now, ignoring flattened data table.
+
 # austraits 3.1.0
 - Change functions to work with traits.build databases that include an identifiers table (or ones that don't)
 

--- a/R/load_austraits.R
+++ b/R/load_austraits.R
@@ -14,7 +14,7 @@
 #' austraits <- load_austraits(version = "3.0.2", path = "data/austraits")
 #' }
 
-load_austraits <- function(doi = NULL, version = NULL, path = "data/austraits", update = FALSE){
+load_austraits <- function(doi = NULL, version = NULL, path = "data/austraits", update = TRUE){
   # Is either doi or version supplied? 
   if(is.null(doi) & is.null(version)){
     stop("Please supply a doi or version! Don't know which one you are after? Try get_versions()!")
@@ -36,7 +36,7 @@ load_austraits <- function(doi = NULL, version = NULL, path = "data/austraits", 
   }
   
   # Load the json
-  res <- load_json(path = path, update = update) 
+  res <- load_json(path = path, update = update)
   
   # Name the response list
   names(res$hits$hits$files) <- res$hits$hits$metadata$version
@@ -69,7 +69,15 @@ load_austraits <- function(doi = NULL, version = NULL, path = "data/austraits", 
   # Setting up the pars
   url <- target$links$self[grep(".rds", target$links$self, fixed = TRUE)]
   
+  if(length(url) > 1) {
+    url <- url[!str_detect(url, "flattened")]
+  }
+  
   file_nm <- file.path(path, target$key[grep(".rds", target$key, fixed = TRUE)])
+  
+  if(length(file_nm) > 1) {
+    file_nm <- file_nm[!str_detect(file_nm, "flattened")]
+  }
 
   #Check if version/doi is download, if not download
   if(! file.exists(file_nm)){


### PR DESCRIPTION
Fix `load_austraits` to work with austraits.build v7.0.0 release. 

AusTraits v7.0.0 release on Zenodo includes two .rds files, the relational database and a flattened data table. This bug fix ignores the flattened data table and loads the relational database when v7.0.0 (and further releases) are requested.

Also, the parameter `update` defaulted to `FALSE`, which means people who have already run `load_austraits` with a previous list of Zenodo releases will not know there have been further releases unless they specifically know to set `update = TRUE`. Hence, the default is now changed to `update = TRUE`.