### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# austraits — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add austraits-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`austraits` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction (incl. the reversed
+  `traits.build` → `austraits` edge), source-of-truth rules, cross-boundary artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: austraits-specific architecture, key entry points, build & test, known gotchas._

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# austraits — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add austraits-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`austraits` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction (incl. the reversed
-  `traits.build` → `austraits` edge), source-of-truth rules, cross-boundary artifacts, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: austraits-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# austraits — agent & contributor guide
+
+`austraits` is an R package of **helpful functions to access, explore and wrangle data** from
+`traits.build` relational databases. It is also the R interface to AusTraits, the Australian plant
+trait database — `load_austraits()` fetches a released `.rds` build.
+
+## Repo-local guidance
+
+- **Code:** `R/` (functions), `tests/` (testthat), `man/` (generated docs), `NAMESPACE`,
+  `vignettes/`. `data/`, `data-raw/`, and `inst/` hold packaged/raw assets (incl. the cheatsheet).
+- **Access entry point:** `load_austraits()` (`R/load_austraits.R`) downloads/loads a released
+  AusTraits build (`.rds`); `get_versions()` / `get_version_latest()` resolve versions.
+- **Wrangle/extract:** `extract_*()` (data/dataset/taxa/trait), `join_*()` (taxa, methods,
+  contributors, locations, context/location properties), `lookup_*()`, `trait_pivot_longer/wider()`,
+  `summarise_database()`, `bind_databases()`, `flatten_database()`, `as_wide_table()`.
+- **Build/test (standard R-package workflow):** `devtools::load_all()`, `devtools::test()`,
+  `devtools::check()`. The package targets `R >= 4.0.0`; tidyverse-style Imports (dplyr, tidyr,
+  purrr, etc.). Lifecycle badge is **stable**.
+- **Default branch:** `master`. Docs/pkgdown site at <https://traitecoevo.github.io/austraits/>.
+
+> Heads-up: `austraits` is the *downstream* access/wrangle layer in the data pipeline, but the
+> R-package install graph runs the other way — `traits.build` **Imports `austraits`** and
+> re-exports a few conversion helpers from it (`convert_df_to_list`, `convert_list_to_df1`,
+> `convert_list_to_df2`, `bind_databases`, `flatten_database` — all in `NAMESPACE`). Changing those
+> helpers can break `traits.build`; run its tests after touching them.
+
+> Heads-up: from Sept 2024 `austraits` works against any `traits.build` database (not just
+> `austraits.build`). `austraits.build` versions **< 5.0 are unsupported** by the current package —
+> older builds need an older tagged `austraits` (e.g. `@v2.2.2`).
+
+---
+
+## AusTraits family — cross-package context
+
+`austraits` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the user-facing access/wrangle API (R
+package) for traits.build-format databases, including AusTraits; loads the released `.rds` via
+`load_austraits()`. Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, source-of-truth rules, cross-boundary
+  artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.Rmd
+++ b/README.Rmd
@@ -118,6 +118,18 @@ Check out [austraits.build](https://github.com/traitecoevo/austraits.build?tab=r
 
 ### Find a bug? `r emo::ji("bug")`
 
-Thank you for finding it! Head over to the GitHub Issues tab and let us know about it! We will try to get to it as soon as we can! 
+Thank you for finding it! Head over to the GitHub Issues tab and let us know about it! We will try to get to it as soon as we can!
+
+## AusTraits family
+
+`austraits` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.
 
 

--- a/README.md
+++ b/README.md
@@ -150,3 +150,15 @@ created
 
 Thank you for finding it! Head over to the GitHub Issues tab and let us
 know about it! We will try to get to it as soon as we can!
+
+## AusTraits family
+
+`austraits` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- README — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)