### PR TITLE
docs: AusTraits family cross-linking, acknowledgements & citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,71 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "austraits" in publications use:'
+type: software
+license: MIT
+title: 'austraits: Helpful functions to access the AusTraits database and wrangle
+  data from other traits.build databases'
+version: 3.1.1
+doi: 10.1038/s41597-021-01006-6
+abstract: '`austraits` allow users to **access, explore and wrangle data** from traits.build
+  relational databases. It is also an R interface to AusTraits, the Australian plant
+  trait database. This package contains functions for joining data from various tables,
+  filtering to specific records, combining multiple databases and visualising the
+  distribution of the data. We expect this package will assist users in working with
+  `traits.build` databases.'
+authors:
+- family-names: Falster
+  given-names: Daniel
+  email: daniel.falster@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-9814-092X
+- family-names: Kar
+  given-names: Fonti
+  email: f.kar@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-2760-3974
+- family-names: Indiarto
+  given-names: Dony
+  orcid: https://orcid.org/0000-0001-9546-8201
+preferred-citation:
+  type: article
+  title: AusTraits, a curated plant trait database for the Australian flora
+  authors:
+  - family-names: Falster
+    given-names: Daniel
+    email: daniel.falster@unsw.edu.au
+    orcid: https://orcid.org/0000-0002-9814-092X
+  - family-names: Gallagher
+    given-names: Rachael
+  - family-names: Wenk
+    given-names: Elizabeth H.
+  - family-names: Wright
+    given-names: Ian J.
+  - family-names: Indiarto
+    given-names: Dony
+    orcid: https://orcid.org/0000-0001-9546-8201
+  - family-names: Andrew
+    given-names: Samuel C.
+  - name: others
+  journal: Scientific Data
+  year: '2021'
+  volume: '8'
+  issue: '1'
+  doi: 10.1038/s41597-021-01006-6
+  url: https://doi.org/10.1038/s41597-021-01006-6
+  start: '254'
+repository-code: https://github.com/traitecoevo/austraits
+url: https://traitecoevo.github.io/austraits/
+contact:
+- family-names: Kar
+  given-names: Fonti
+  email: f.kar@unsw.edu.au
+  orcid: https://orcid.org/0000-0002-2760-3974
+keywords:
+- australia
+- database
+- plants
+- traits
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -132,4 +132,21 @@ read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta
 in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
 knowledge and governance hub — before filing.
 
+## Acknowledgements
+
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
+
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).
+
 

--- a/README.md
+++ b/README.md
@@ -162,3 +162,20 @@ Contributing? Issues across the family are tracked on one board,
 read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
 in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
 knowledge and governance hub — before filing.
+
+## Acknowledgements
+
+AusTraits is made possible by contributions from our partner organisations — the
+[University of New South Wales](https://www.unsw.edu.au/),
+[Western Sydney University](https://www.westernsydney.edu.au/),
+[Botanic Gardens of Sydney](https://www.botanicgardens.org.au/),
+[the University of Melbourne](https://www.unimelb.edu.au/),
+the [Atlas of Living Australia](https://www.ala.org.au/), and the Australian Government
+[Department of Climate Change, Energy, the Environment and Water](https://www.dcceew.gov.au) — and
+from our [advisory board, data contributors, and past partners](https://austraits.org/team/team-partners.html).
+
+AusTraits is a co-investment partnership with the
+[Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data
+Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the
+Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris)
+(NCRIS).

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,14 +1,27 @@
 citHeader("To cite austraits in publications use:")
 
-citEntry(
-  entry    = "Article",
+bibentry(
+  bibtype  = "Article",
   title    = "AusTraits, a curated plant trait database for the Australian flora",
-  author   ="Daniel Falster, Rachael Gallagher, Elizabeth Wenk et al.",
+  author   = c(
+    person("Daniel", "Falster"),
+    person("Rachael", "Gallagher"),
+    person("Elizabeth H.", "Wenk"),
+    person("Ian J.", "Wright"),
+    person("Dony", "Indiarto"),
+    person("Samuel C.", "Andrew"),
+    person(family = "others")
+  ),
   journal  = "Scientific Data",
   year     = "2021",
   volume   = "8",
   number   = "1",
-  pages    = "254 - 274",
+  pages    = "254",
+  doi      = "10.1038/s41597-021-01006-6",
   url      = "https://doi.org/10.1038/s41597-021-01006-6",
-  textVersion = paste("Falster, D., Gallagher, R., Wenk, E.H. et al. AusTraits, a curated plant trait database for the Australian flora. Sci Data 8, 254 (2021). https://doi.org/10.1038/s41597-021-01006-6")
+  textVersion = paste(
+    "Falster, D., Gallagher, R., Wenk, E.H. et al. (2021)",
+    "AusTraits, a curated plant trait database for the Australian flora.",
+    "Scientific Data 8, 254. https://doi.org/10.1038/s41597-021-01006-6"
+  )
 )


### PR DESCRIPTION
Part of the family-wide README usability pass (see the plan in `traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

Standardises across the AusTraits family:
- the **AusTraits family** cross-link block (→ austraits.org, board #9, `austraits-meta`)
- the canonical **partner + ARDC/NCRIS co-investment acknowledgement** (NCRIS "enabled by")
- a **How to cite** section drawn from the family citation set

...plus repo-specific README fixes. Citation and acknowledgement wording come from the canonical sources in `austraits-meta` (`references/`, `acknowledgements.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)